### PR TITLE
Удаление фильмов и пользователей по ID

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -46,8 +46,8 @@ public class FilmController {
         return filmService.updateFilm(updatedFilm);
     }
 
-    @DeleteMapping
-    public void delete(@Valid @RequestBody int filmId) {
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable("id") @Positive int filmId) {
         filmService.deleteFilm(filmId);
     }
 

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -48,6 +48,7 @@ public class FilmController {
 
     @DeleteMapping("/{id}")
     public void delete(@PathVariable("id") @Positive int filmId) {
+        log.info("Delete film with id {}", filmId);
         filmService.deleteFilm(filmId);
     }
 

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/UserController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/UserController.java
@@ -1,6 +1,7 @@
 package ru.yandex.practicum.filmorate.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -29,10 +30,15 @@ public class UserController {
         return userService.findAll();
     }
 
-    @DeleteMapping
-    public void deleteUser(@Valid @RequestBody int id) {
-        log.info("Delete user with id {} ", id);
-        userService.deleteUser(id);
+    @GetMapping("/{id}")
+    public UserDto getUserById(@PathVariable("id") int id) {
+        return userService.getUserByID(id);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteUser(@PathVariable("id") @Positive int userId) {
+        log.info("Delete user with id {}", userId);
+        userService.deleteUser(userId);
     }
 
     @PostMapping

--- a/src/main/java/ru/yandex/practicum/filmorate/dal/user/UserRepository.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/dal/user/UserRepository.java
@@ -71,7 +71,7 @@ public class UserRepository extends BaseRepository<User> implements UserStorage 
 
     @Override
     public void deleteUser(int id) {
-        delete(DELETE_USER_FROM_ALL_FRIENDS, id);
+        delete(DELETE_USER_FROM_ALL_FRIENDS, id, id);
         delete(DELETE_BY_ID, id);
     }
 

--- a/src/main/java/ru/yandex/practicum/filmorate/service/UserService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/UserService.java
@@ -57,8 +57,10 @@ public class UserService {
     }
 
     public void deleteUser(int userId) {
-        Optional<User> user = userStorage.findUser(userId);
-        user.ifPresent(value -> userStorage.deleteUser(value.getId()));
+        if (userStorage.findUser(userId).isEmpty()) {
+            throw new NotFoundException("User with id " + userId + " not found");
+        }
+        userStorage.deleteUser(userId);
     }
 
     public List<UserDto> findAll() {


### PR DESCRIPTION
Реализовано удаление фильмов и пользователей по ID.
- DELETE /films/{id}
- DELETE /users/{id}
- Добавлен недостающий GET /users/{id} (без него тест в постмане падал)
- Обеспечено возвращение 404 при удалении несуществующей сущности
- Исправлена ошибка SQL при удалении связей в друзьях
Тесты в постмане прогнал - все прошли